### PR TITLE
Synthesis of executing and finished for iOS 8

### DIFF
--- a/ChimpKit3/ChimpKitRequest.m
+++ b/ChimpKit3/ChimpKitRequest.m
@@ -24,7 +24,8 @@
 @implementation ChimpKitRequest
 
 @synthesize headerFields = _headerFields;
-
+@synthesize executing = _executing;
+@synthesize finished = _finished;
 
 #pragma mark - Properites
 


### PR DESCRIPTION
Due to the changes in iOS to `NSOperationQueue`, there was a compiler error because automatic property synthesis could not synthesize the ivar for `executing` and `finished` since the superclass declares them as `readonly`.
