### PR TITLE
BUG FIX: Explicitly include `UIKit` for projects that don't build with a precompile header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/ChimpKit3/ChimpKit.h
+++ b/ChimpKit3/ChimpKit.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 MailChimp. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 
 #define kCKDebug					0

--- a/ChimpKit3/Helper Objects/CKAuthViewController.m
+++ b/ChimpKit3/Helper Objects/CKAuthViewController.m
@@ -240,8 +240,10 @@
 				self.authFailed(error);
 			}
 		} else {
-			NSString *responseString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-			if (kCKDebug) NSLog(@"Response String: %@", responseString);
+            if (kCKDebug) {
+                NSString *responseString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+                NSLog(@"Response String: %@", responseString);
+            }
 			
 			NSError *error = nil;
 			id responseData = [NSJSONSerialization JSONObjectWithData:data

--- a/ChimpKit3/Helper Objects/CKSubscribeAlertView.m
+++ b/ChimpKit3/Helper Objects/CKSubscribeAlertView.m
@@ -99,9 +99,11 @@ subscribeButtonTitle:(NSString *)subscribeButtonTitle
 		
 		[[ChimpKit sharedKit] callApiMethod:@"lists/subscribe"
 								 withParams:params
-					   andCompletionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
-						   NSString *responseString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-						   if (kCKDebug) NSLog(@"Response String: %@", responseString);
+                       andCompletionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+                           if (kCKDebug) {
+                               NSString *responseString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+                               NSLog(@"Response String: %@", responseString);
+                           }
 						   
                            id parsedResponse = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
                            


### PR DESCRIPTION
The ChimpKit SDK doesn't build as a git submodule for projects that don't use a PCH.

Also, I've added a `.gitignore` to eliminate Finder's `.DS_Store` files from getting committed into the repo.
